### PR TITLE
Ofeliaの導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
 # JOJIハウス 入退室管理システム(jojihouse-entrance-system)
 
-# cron設定メモ
-
-```
-crontab -e
-```
-
-```
-0 * * * * cd /root/jojihouse-system/ && /usr/local/bin/docker compose run --rm backup
-```
-
 # API エンドポイント一覧
 
 ## ユーザー関連

--- a/compose.yml
+++ b/compose.yml
@@ -89,6 +89,25 @@ services:
       - postgreSql
       - mongoDb
 
+  # 定期実行を管理するスケジューラサービス (Ofelia)
+  scheduler:
+    # image: mcuadros/ofelia:latest
+    build:
+      context: ./scheduler
+      dockerfile: Dockerfile
+    container_name: ofelia_scheduler
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      TZ: Asia/Tokyo
+    command: daemon --docker
+    labels:
+      # sec min hour day month day_of_week
+      # 毎時0分0秒にバックアップタスクを実行
+      ofelia.job-local.backup-task.schedule: "0 0 * * * *"
+      ofelia.job-local.backup-task.command: "docker start jojihouse-db-backup"
+
 networks:
   myNetwork:
     driver: bridge

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -1,0 +1,6 @@
+# Ofeliaの公式イメージをベースにする
+FROM mcuadros/ofelia:latest
+
+# Ofeliaコンテナ内でdockerコマンドを使えるようにインストールする
+# OfeliaはAlpine Linuxベースなのでapkコマンドを使用
+RUN apk add --no-cache docker-cli


### PR DESCRIPTION
#42 で実装を断念したOfeliaによる定期実行を実装
本プルリクのマージに伴い、cronの登録は不要となる

- **feat: スケジューラサービス(Ofelia)を追加し、バックアップタスクを定期実行するように設定**
- **docs: ofelia導入に伴い、cron登録のREADMEを削除**
