### PR TITLE
PaymentLogを削除せずdisableに変更して無効にするようにした

### DIFF
--- a/jojihouse-system/api/model/response/payment_response.go
+++ b/jojihouse-system/api/model/response/payment_response.go
@@ -5,13 +5,16 @@ import (
 )
 
 type PaymentLog struct {
-	ID          string    `json:"id"`
-	UserID      int       `json:"user_id"`
-	UserName    string    `json:"user_name"`
-	Time        time.Time `json:"time"`
-	Description string    `json:"description"`
-	Amount      int       `json:"amount"`
-	Payway      string    `json:"payway"`
+	ID          string     `json:"id"`
+	UserID      int        `json:"user_id"`
+	UserName    string     `json:"user_name"`
+	Time        time.Time  `json:"time"`
+	Description string     `json:"description"`
+	Amount      int        `json:"amount"`
+	Payway      string     `json:"payway"`
+	IsDeleted   bool       `json:"is_deleted"`
+	DeletedBy   *int       `json:"deleted_by"`
+	DeletedAt   *time.Time `json:"deleted_at"`
 }
 
 type MonthlyPaymentLog struct {

--- a/jojihouse-system/internal/model/payment.go
+++ b/jojihouse-system/internal/model/payment.go
@@ -9,8 +9,11 @@ import (
 
 var ErrInvalidPaymentLog = errors.New("invalid payment log")
 var ErrPaymentLogNotFound = errors.New("payment log not found")
+
 var ErrPaymentLogSeemsTicketPurchase = errors.New("payment log seems to be for ticket purchase but has no linked RemainingEntriesLogID")
 var ErrPaymentLogTooOldToDelete = errors.New("payment log is too old to delete, over 14 days")
+var ErrPaymentLogAlreadyDeleted = errors.New("payment log is already deleted")
+var ErrPaymentLogFaledToDelete = errors.New("failed to delete payment log")
 
 type PaymentLog struct {
 	ID                     primitive.ObjectID  `json:"id" bson:"_id,omitempty"`

--- a/jojihouse-system/internal/model/payment.go
+++ b/jojihouse-system/internal/model/payment.go
@@ -13,6 +13,7 @@ var ErrPaymentLogNotFound = errors.New("payment log not found")
 var ErrPaymentLogSeemsTicketPurchase = errors.New("payment log seems to be for ticket purchase but has no linked RemainingEntriesLogID")
 var ErrPaymentLogTooOldToDelete = errors.New("payment log is too old to delete, over 14 days")
 var ErrPaymentLogAlreadyDeleted = errors.New("payment log is already deleted")
+var ErrPaymentLogIsnotDeleted = errors.New("payment log is not deleted")
 var ErrPaymentLogFaledToDelete = errors.New("failed to delete payment log")
 
 type PaymentLog struct {

--- a/jojihouse-system/internal/model/payment.go
+++ b/jojihouse-system/internal/model/payment.go
@@ -20,6 +20,9 @@ type PaymentLog struct {
 	Amount                 int                 `json:"amount" bson:"amount"`
 	Payway                 string              `json:"payway" bson:"payway"`
 	RemainingEntiriesLogID *primitive.ObjectID `json:"remaining_entries_log_id" bson:"remaining_entries_log_id"`
+	IsDeleted              bool                `bson:"is_deleted"`
+	DeletedBy              *int                `bson:"deleted_by,omitempty"`
+	DeletedAt              *time.Time          `bson:"deleted_at,omitempty"`
 }
 
 type MonthlyPaymentLog struct {

--- a/jojihouse-system/internal/repository/payment_log_repo.go
+++ b/jojihouse-system/internal/repository/payment_log_repo.go
@@ -82,14 +82,14 @@ func (r *PaymentLogRepository) GetAllPaymentLogs(lastID primitive.ObjectID, limi
 }
 
 // MonthlyTotalAmount は月次の支払い合計額を表す構造体です
-type MonthlyTotalAmount struct {
+type monthlyTotalAmount struct {
 	Total      int
 	OliveTotal int
 	CashTotal  int
 }
 
 // getMonthlyTotalAmount は指定された年月の支払い合計額を取得します
-func (r *PaymentLogRepository) getMonthlyTotalAmount(year int, month int) (*MonthlyTotalAmount, error) {
+func (r *PaymentLogRepository) getMonthlyTotalAmount(year int, month int) (*monthlyTotalAmount, error) {
 	ctx := context.Background()
 	startDate := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.Local)
 	endDate := startDate.AddDate(0, 1, 0)
@@ -127,7 +127,7 @@ func (r *PaymentLogRepository) getMonthlyTotalAmount(year int, month int) (*Mont
 		return nil, fmt.Errorf("合計値の集計結果デコードに失敗: %w", err)
 	}
 
-	totals := &MonthlyTotalAmount{}
+	totals := &monthlyTotalAmount{}
 	for _, aggResult := range aggResults {
 		totals.Total += aggResult.Total
 		switch aggResult.ID {

--- a/jojihouse-system/internal/repository/payment_log_repo.go
+++ b/jojihouse-system/internal/repository/payment_log_repo.go
@@ -48,6 +48,7 @@ func (r *PaymentLogRepository) GetAllPaymentLogs(lastID primitive.ObjectID, limi
 			{Key: "_id", Value: bson.D{
 				{Key: "$lt", Value: lastID},
 			}},
+			{Key: "is_deleted", Value: false},
 		}
 	}
 	cursor, err := r.db.Collection("payment_log").Find(context.Background(), filter, opts)
@@ -86,6 +87,7 @@ func (r *PaymentLogRepository) getMonthlyTotalAmount(year int, month int) (*Mont
 			{Key: "$gte", Value: startDate},
 			{Key: "$lt", Value: endDate},
 		}},
+		{Key: "is_deleted", Value: false},
 	}
 
 	pipeline := mongo.Pipeline{
@@ -137,6 +139,7 @@ func (r *PaymentLogRepository) GetMonthlyPaymentLogs(year int, month int) (*mode
 			{Key: "$gte", Value: startDate},
 			{Key: "$lt", Value: endDate},
 		}},
+		{Key: "is_deleted", Value: false},
 	}
 
 	totals, err := r.getMonthlyTotalAmount(year, month)

--- a/jojihouse-system/internal/repository/payment_log_repo.go
+++ b/jojihouse-system/internal/repository/payment_log_repo.go
@@ -234,10 +234,12 @@ func (r *PaymentLogRepository) DeletePaymentLog(id primitive.ObjectID) error {
 	now := time.Now()
 	res, err := r.db.Collection("payment_log").UpdateOne(
 		ctx,
-		bson.D{
-			{Key: "_id", Value: id},
-			{Key: "is_deleted", Value: false}, // 既に削除されていないことを確認
-		},
+		append(
+			bson.D{
+				{Key: "_id", Value: id},
+			},
+			r.activeDeletedFilter()...,
+		),
 		bson.D{{
 			Key: "$set",
 			Value: bson.D{

--- a/jojihouse-system/internal/service/admin_management_service.go
+++ b/jojihouse-system/internal/service/admin_management_service.go
@@ -291,6 +291,9 @@ func (s *AdminManagementService) GetPaymentLogByID(logID string) (*response.Paym
 		Description: log.Description,
 		Amount:      log.Amount,
 		Payway:      log.Payway,
+		IsDeleted:   log.IsDeleted,
+		DeletedBy:   log.DeletedBy,
+		DeletedAt:   log.DeletedAt,
 	}
 
 	return responseLog, nil


### PR DESCRIPTION
- **feat: paymentLogのmodelを変更**
- **feat: 削除処理をis_deletedフラグの書き換えに変更**
- **feat: 支払いログ取得時にis_deletedでフィルターを掛けた**
- **fix: paymentLogのis_deletedがnullでもfalseとして扱うようにした**
- **refactor: activeDeletedFilterを追加し、支払いログの取得時にis_deletedフィルターを統一**
- **refactor: 内部で用いる構造体をプライベートに変更**
- **feat: paymentlogのレスポンスにis_deleted関連の情報追加**
- **fix: paymentlogの削除時のフィルターを他の関数と統一**
